### PR TITLE
Some posts with reusable blocks are missing styles

### DIFF
--- a/class-gutenberg-css.php
+++ b/class-gutenberg-css.php
@@ -135,11 +135,11 @@ if ( ! class_exists( '\ThemeIsle\GutenbergCSS' ) ) {
 					$reusable_block = get_post( $block['attrs']['ref'] );
 
 					if ( ! $reusable_block || 'wp_block' !== $reusable_block->post_type ) {
-						return;
+						return $style;
 					}
 
 					if ( 'publish' !== $reusable_block->post_status || ! empty( $reusable_block->post_password ) ) {
-						return;
+						return $style;
 					}
 
 					$blocks = $this->parse_blocks( $reusable_block->post_content );


### PR DESCRIPTION
Posts with reusable blocks that trigger either of the conditionals of `cycle_through_blocks()` that also have other blocks _before_ the reusable block will be missing some or all of the custom styles entered for other blocks on that post.

Returning nothing in these instances resets the `$style` variable, so returning the existing contents of `$style` seems to fix the issue.

This would need to be tested against whatever scenarios you're testing against. I've only tested it in the limited use case of the issue I see on a client site.

Fixes #9 